### PR TITLE
Add a separate file to configure the apiURL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+js/config.js
+

--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
   <script src="js/d3.min.js"></script>
   <script src="js/c3.min.js"></script>
   <script src="js/vue.min.js"></script>
+  <script src="js/config.js"></script>
   <script src="js/index.js"></script>
 </body>
 </html>

--- a/js/config_sample.js
+++ b/js/config_sample.js
@@ -1,0 +1,5 @@
+// Rename this file to config.js to have it loaded before index.js and customise your variables
+
+// This will override the default apiURL value in index.js
+// Set it to your custom URL
+var apiURL = 'http://myserver:4242/'

--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,4 @@
-var apiURL = 'http://localhost:8080/'
+var apiURL = typeof(apiURL) == 'undefined' ? 'http://localhost:8080/' : apiURL
 
 var app = new Vue({
     el: '#app',


### PR DESCRIPTION
The default API url did not work for me but I don't want to check in my modified config in the public repo.
This change allows me to put my overrides in a file and let the default exist unchanged.