### PR TITLE
Change the graph in a global graph that shows all hour totals

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,5 @@
-var apiURL = 'http://localhost:8080/'
+//var apiURL = 'http://localhost:8080/'
+var apiURL = 'http://192.168.12.10:8053/'
 
 var app = new Vue({
     el: '#app',
@@ -60,10 +61,12 @@ var app = new Vue({
           var cols = []
           var clients = []
           var xPlot = ['x']
+          var labels = {}
 
           self.queries.items.forEach(function(item) {
             var d = new Date(item.date * 1000)
-            var hour = d.getHours()
+            var hour = Math.floor(item.date/3600)
+            var tag = d.getDate()+'/'+(d.getMonth()+1)+'/'+d.getFullYear()+' '+d.getHours()
 
             if (clients[item.client]) {
               if (clients[item.client].hours[hour]) {
@@ -79,6 +82,7 @@ var app = new Vue({
 
             if (xPlot.indexOf(hour) == -1) {
               xPlot.push(hour)
+              labels[hour] = tag
             }
           })
 
@@ -104,6 +108,9 @@ var app = new Vue({
                     label: {
                       text: 'time',
                       position: 'outer-middle'
+                    },
+                    tick: {
+                      format: function (hour) { return labels[hour]; }
                     }
                 },
                 y: {


### PR DESCRIPTION
The old graph was aggregating per hour over multiple days. This change will create a graph aggregated per hour/per day.
I am ok to change this in a fix to always enter the hour sorted in the graph instead of adding them in the  order in which they're found in the data, which creates a strange graph across the 23-0 change